### PR TITLE
Always just use Platform.openURL to open URLs

### DIFF
--- a/src/processing/mode/p5js/p5jsEditor.java
+++ b/src/processing/mode/p5js/p5jsEditor.java
@@ -433,19 +433,7 @@ public class p5jsEditor extends Editor {
         }
         statusNotice("Server running at " + server.getAddress());
 
-        if (Desktop.isDesktopSupported()) {
-          // use this version so that errors pop out as exceptions,
-          // and we can show them as errors in the PDE (otherwise weird
-          // URL opening problems are confusing for new users)
-          Desktop.getDesktop().browse(new URI(server.getAddress()));
-
-        } else {
-          // if Desktop not available, try the Platform version,
-          // which will try platform tricks (but is wrapped so the Exception
-          // doesn't propagate, and therefore we're not using this by default)
-          // https://github.com/fathominfo/processing-p5js-mode/issues/17
-          Platform.openURL(server.getAddress());
-        }
+        Platform.openURL(server.getAddress());
       }
     } catch (Exception e) {
       statusError(e);


### PR DESCRIPTION
I'm using a window manager that isn't well-supported by Java's `Desktop` API, and I get the same error as in #17 when I try to run a sketch:

```
java.lang.UnsupportedOperationException: The BROWSE action is not supported on the current platform!
	at java.desktop/java.awt.Desktop.checkActionSupport(Desktop.java:381)
	at java.desktop/java.awt.Desktop.browse(Desktop.java:531)
	at processing.app.platform.DefaultPlatform.openURL(DefaultPlatform.java:191)
	at processing.app.platform.LinuxPlatform.openURL(LinuxPlatform.java:126)
	at processing.app.Platform.openURL(Platform.java:152)
	at processing.mode.p5js.p5jsEditor.handleRun(p5jsEditor.java:440)
...
```

It seems the fix from #17 doesn't work in all cases; in my situtation, `Desktop.isDesktopSupported()` returns true but the specific `BROWSE` action isn't supported on my platform.

Is there a reason we can't just call `Platform.openURL()` in all cases? With this patch, I get an error message saying the URL couldn't be opened (https://postimg.cc/Mny4t56t), as well as a traceback in the Processing console (https://postimg.cc/BX2MGvrn), but I'm still able to browse to the URL manually and work on my sketch, thanks to the error handling in `Platform.openURL`. In what way would this not be the intended behavior?